### PR TITLE
[FREEPBX-8237] Fix interface parse regexp to make netmask optional

### DIFF
--- a/chanpj.page.php
+++ b/chanpj.page.php
@@ -43,7 +43,7 @@ if ($sa != "no") {
 		}
 
 		// Strip netmask off the end of the IP address
-		$ret = preg_match("/(\d*+.\d*+.\d*+.\d*+)\/(\d*+)/", $vals[3], $ip);
+		$ret = preg_match("/(\d*+.\d*+.\d*+.\d*+)[\/(\d*+)]*/", $vals[3], $ip);
 
 		$interfaces[$vals[$int]] = array($ip[1], $vals[$int], $ip[2]);
 	}


### PR DESCRIPTION
In the regexp parsing the output of /sbin/ip, don't require a CIDR netmask as some interfaces (tun) don't include it. Closes [FREEPBX-8237].
