### PR TITLE
Fix PHP Fatal Error in PHP7

### DIFF
--- a/Sipsettings.class.php
+++ b/Sipsettings.class.php
@@ -330,7 +330,7 @@ class Sipsettings extends FreePBX_Helpers implements BMO {
 	}
 
 
-	public function doDialplanHook(&$ext, $null, $null) {
+	public function doDialplanHook(&$ext, $null, $null_) {
 		$ext->addGlobal('ALLOW_SIP_ANON', strtolower($this->getConfig("allowanon")));
 	}
 


### PR DESCRIPTION
This especially allows `fwconsole` to work properly.