### PR TITLE
remove some debugging code

### DIFF
--- a/install.php
+++ b/install.php
@@ -22,11 +22,6 @@ outn(_("checking for sipsettings table.."));
 $tsql = "SELECT * FROM `sipsettings` limit 1";
 $check = $db->getRow($tsql, DB_FETCHMODE_ASSOC);
 
-$ok = FreePBX::create()->astman->command('core show version');
-if (preg_match('/^Asterisk (?:SVN-|GIT-)?(?:branch-)?(\d+(\.\d+)*)(-?(.*)) built/', $astver, $matches) && !empty($matches[1])) {
-	print_r($matches[1]);
-}
-
 // Figure out if we're using asterisk 11 or 12.
 $version = FreePBX::Config()->get('ASTVERSION');
 if (!empty($version)) {


### PR DESCRIPTION
`$astver` was not defined, so it wasn't doing anything except throwing notices. Needs backport to 13 as well.